### PR TITLE
mod/turnitintooltwo: fix language string references

### DIFF
--- a/mod/turnitintooltwo/settings.php
+++ b/mod/turnitintooltwo/settings.php
@@ -75,8 +75,8 @@ if ($ADMIN->fulltree) {
 
     $ynoptions = array(0 => get_string('no'), 1 => get_string('yes'));
 
-    $settings->add(new admin_setting_configselect('turnitintooltwo/enablediagnostic', get_string('turnitindiagnostic', 'turnitintool'),
-                       get_string('turnitindiagnostic_desc', 'turnitintool'), 0, $ynoptions));
+    $settings->add(new admin_setting_configselect('turnitintooltwo/enablediagnostic', get_string('turnitindiagnostic', 'turnitintooltwo'),
+                       get_string('turnitindiagnostic_desc', 'turnitintooltwo'), 0, $ynoptions));
 
     $settings->add(new admin_setting_configselect('turnitintooltwo/usegrademark',
                                                     get_string('turnitinusegrademark', 'turnitintooltwo'),


### PR DESCRIPTION
Hi John, just a minor fix that I noticed during the plugin upgrade.
