### PR TITLE
Fix maximum upload limit when $CFG->maxbytes is 0

### DIFF
--- a/mod/turnitintooltwo/mod_form.php
+++ b/mod/turnitintooltwo/mod_form.php
@@ -181,7 +181,7 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
         $mform->addElement('hidden', 'portfolio', 0);
         $mform->setType('portfolio', PARAM_INT);
 
-        $maxbytes1 = ($CFG->maxbytes > TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE) ?
+        $maxbytes1 = ($CFG->maxbytes === 0 || $CFG->maxbytes > TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE) ?
                             TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE : $CFG->maxbytes;
         $maxbytes2 = ($COURSE->maxbytes > TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE) ?
                             TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE : $COURSE->maxbytes;


### PR DESCRIPTION
$CFG->maxbytes is set to 0 by default (PHP limit) which is less than (but could resolve to a size greater than) TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE
