### PR TITLE
plagiarism_turnitin: Fix errors page error caused by file absence.

### DIFF
--- a/plagiarism/turnitin/lang/en/plagiarism_turnitin.php
+++ b/plagiarism/turnitin/lang/en/plagiarism_turnitin.php
@@ -9,3 +9,4 @@ $string['turnitin'] = 'Turnitin';
 $string['turnitin:enable'] = 'Enable Turnitin';
 $string['turnitin:viewsimilarityscore'] = 'View Similarity Score';
 $string['turnitin:viewfullreport'] = 'View Originality Report';
+$string['filedoesnotexist'] = 'File has been deleted';

--- a/plagiarism/turnitin/turnitinplugin_view.class.php
+++ b/plagiarism/turnitin/turnitinplugin_view.class.php
@@ -326,12 +326,15 @@ class turnitinplugin_view {
 
                     if ($v->submissiontype == "file") {
                         $fs = get_file_storage();
-                        $file = $fs->get_file_by_hash($v->identifier);
-                        $cells["file"] = new html_table_cell(html_writer::link($CFG->wwwroot.'/pluginfile.php/'.
+                        if ($file = $fs->get_file_by_hash($v->identifier)) {
+                            $cells["file"] = new html_table_cell(html_writer::link($CFG->wwwroot.'/pluginfile.php/'.
                                                 $file->get_contextid().'/'.$file->get_component().'/'.$file->get_filearea().'/'.
                                                 $file->get_itemid().'/'.$file->get_filename(),
                                                 $OUTPUT->pix_icon('fileicon', 'open '.$file->get_filename(), 'mod_turnitintooltwo').
                                                     " ".$file->get_filename()));
+                        } else {
+                            $cells["file"] = get_string('filedoesnotexist', 'plagiarism_turnitin');
+                        }
                     } else {
                         $cells["file"] = str_replace('_', ' ', ucfirst($v->submissiontype));
                     }


### PR DESCRIPTION
There are cases when file with status 'error' is deleted in assignments, this makes plagiarism plugin Errors tab  throwing fatal error (because it can't retrieve the file from storage any more using the hash). The patch is fixing the issue.
