### PR TITLE
Fix for grades fetching

### DIFF
--- a/plagiarism/turnitin/lib.php
+++ b/plagiarism/turnitin/lib.php
@@ -464,6 +464,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
                 // Get user's grades.
                 $duedate = 0;
+                $currentgradequery = false;
                 if ($cm->modname == 'forum') {
                     static $gradeitem;
                     if (empty($gradeitem)) {


### PR DESCRIPTION
This allows us to use custom modules which implement the Plagiarism API without having the plugin try to get grademark grades for them.
