### PR TITLE
Setting dates on a part should work when Location setting is not set to ...

### DIFF
--- a/mod/turnitintooltwo/ajax.php
+++ b/mod/turnitintooltwo/ajax.php
@@ -54,7 +54,18 @@ switch ($action) {
                 case "dtdue":
                 case "dtpost":
                     $fieldvalue = required_param('value', PARAM_RAW);
-                    $fieldvalue = strtotime($fieldvalue);
+                    // We need to work out the users timezone or GMT offset.
+                    $usertimezone = get_user_timezone();
+                    if (is_numeric($usertimezone)) {
+                        if ($usertimezone > 0) {
+                            $usertimezone = "GMT+$usertimezone";
+                        } else if ($usertimezone < 0) {
+                            $usertimezone = "GMT$usertimezone";
+                        } else {
+                            $usertimezone = 'GMT';
+                        }
+                    }
+                    $fieldvalue = strtotime($fieldvalue.' '.$usertimezone);
                     break;
             }
 

--- a/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
+++ b/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
@@ -1051,9 +1051,6 @@ class turnitintooltwo_assignment {
                         $setmethod = "setFeedbackReleaseDate";
                         break;
                 }
-                if ($CFG->ostype != 'WINDOWS') {
-                    $fieldvalue = userdate($fieldvalue, '%s');
-                }
                 $assignment->$setmethod(gmdate("Y-m-d\TH:i:s\Z", $fieldvalue));
                 break;
         }


### PR DESCRIPTION
Setting dates on a part should work when Location setting is not set to 'Server's local time'

On a CentOS server with its timezone set to "Europe/London" during daylight savings the timezone is reported as BST, while during non-daylight savings it is reported as GMT. This causes issues with dates set for daylight savings times while the server is in a non-daylight savings time. The bugs caused by this can be worked around by setting Moodle's Location settings to have a timezone of "Europe/London"

Unfortunately in this configuration it seems that setting part dates via the turnitintooltwo AJAX causes times during daylight savings to be incorrect.

This change does two things:

* Ensures that the date string passed via AJAX is changed into the correct timestamp based on the timezone settings of the user.
* Removes a call to userdate as the timestamp passed should always be UCT already at this point.

We reported this via Turnitin Product Support Case #00338353 a couple of months ago