### PR TITLE
Ensure there is still a valid course module in cron

### DIFF
--- a/plagiarism/turnitin/lib.php
+++ b/plagiarism/turnitin/lib.php
@@ -1376,7 +1376,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $cm = get_coursemodule_from_id('', $assignment->cm);
 
             // Don't update for forums as post date will be start date in this instance as there is no gradebook.
-            if ($cm->modname != 'forum') {
+            if ($cm && $cm->modname != 'forum') {
                 // Get course data.
                 $coursedata = turnitintooltwo_assignment::get_course_data($cm->course, 'PP');
                 if (empty($coursedata->turnitin_cid)) {


### PR DESCRIPTION
plagiarism_turnitin_config isn't cleared out when course modules are deleted
