### PR TITLE
Prevent unstarted modules stopping assignment update.

### DIFF
--- a/plagiarism/turnitin/lib.php
+++ b/plagiarism/turnitin/lib.php
@@ -1410,7 +1410,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                         $dtstart = $cm->added;
                     }
                     if ($dtstart > time()) {
-                        break;
+                        continue;
                     }
 
                     if ($plagiarism_post_date = $DB->get_record_select('plagiarism_turnitin_config',


### PR DESCRIPTION
Hi John, thanks for fixing the issue with assignments in the future being updated on every run of the cron, but the fix is now causing the assignment update to bail out as soon as it hits one of these. Cheers, Michael.
