### PR TITLE
Handle exceptions in cron assignment update

### DIFF
--- a/plagiarism/turnitin/lib.php
+++ b/plagiarism/turnitin/lib.php
@@ -1378,72 +1378,78 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                                         " name = ? ", array('turnitin_assignid'), 'cm, value');
 
         foreach ($assignments as $assignment) {
-            $cm = get_coursemodule_from_id('', $assignment->cm);
-
-            if ($cm) {
-                $moduledata = $DB->get_record($cm->modname, array('id' => $cm->instance));
-
-                // Don't update for forums as post date will be start date in this instance as there is no gradebook.
-                if ($cm->modname != 'forum') {
-                    // Get course data.
-                    $coursedata = turnitintooltwo_assignment::get_course_data($cm->course, 'PP');
-                    if (empty($coursedata->turnitin_cid)) {
-                        // Course may existed in a previous incarnation of this plugin.
-                        // Get this and save it in courses table if so.
-                        if ($turnitincid = $this->get_previous_course_id($cm)) {
-                            $coursedata = $this->migrate_previous_course($coursedata, $turnitincid);
+            try {
+                $cm = get_coursemodule_from_id('', $assignment->cm);
+                
+                if ($cm) {
+                    $moduledata = $DB->get_record($cm->modname, array('id' => $cm->instance));
+                
+                    // Don't update for forums as post date will be start date in this instance as there is no gradebook.
+                    if ($cm->modname != 'forum') {
+                        // Get course data.
+                        $coursedata = turnitintooltwo_assignment::get_course_data($cm->course, 'PP');
+                        if (empty($coursedata->turnitin_cid)) {
+                            // Course may existed in a previous incarnation of this plugin.
+                            // Get this and save it in courses table if so.
+                            if ($turnitincid = $this->get_previous_course_id($cm)) {
+                                $coursedata = $this->migrate_previous_course($coursedata, $turnitincid);
+                            } else {
+                                // Otherwise create new course in Turnitin.
+                                $tiicoursedata = $this->create_tii_course($cm, $coursedata);
+                                $coursedata->turnitin_cid = $tiicoursedata->turnitin_cid;
+                                $coursedata->turnitin_ctl = $tiicoursedata->turnitin_ctl;
+                            }
+                        }
+                
+                        // Only update modules that haven't started yet.
+                        $dtstart = 0;
+                        if (!empty($moduledata->allowsubmissionsfromdate)) {
+                            $dtstart = $moduledata->allowsubmissionsfromdate;
+                        } else if (!empty($moduledata->timeavailable)) {
+                            $dtstart = $moduledata->timeavailable;
                         } else {
-                            // Otherwise create new course in Turnitin.
-                            $tiicoursedata = $this->create_tii_course($cm, $coursedata);
-                            $coursedata->turnitin_cid = $tiicoursedata->turnitin_cid;
-                            $coursedata->turnitin_ctl = $tiicoursedata->turnitin_ctl;
+                            $dtstart = $cm->added;
                         }
-                    }
-
-                    // Only update modules that haven't started yet.
-                    $dtstart = 0;
-                    if (!empty($moduledata->allowsubmissionsfromdate)) {
-                        $dtstart = $moduledata->allowsubmissionsfromdate;
-                    } else if (!empty($moduledata->timeavailable)) {
-                        $dtstart = $moduledata->timeavailable;
-                    } else {
-                        $dtstart = $cm->added;
-                    }
-                    if ($dtstart > time()) {
-                        break;
-                    }
-
-                    if ($plagiarism_post_date = $DB->get_record_select('plagiarism_turnitin_config',
-                                                " name = ? AND cm = ? ", array('plagiarism_post_date', $cm->id), 'value')) {
-
-                        $post_date = $plagiarism_post_date->value;
-                        $gradeitem = $DB->get_record('grade_items', array('iteminstance' => $cm->instance, 
-                                                        'itemmodule' => $cm->modname, 'itemnumber' => 0));
-
-                        // 1 means grade is always hidden, 0 means it's never hidden so we make it the same as start date.
-                        // Otherwise there is a hidden until date which we use as the post date.
-                        switch ($gradeitem->hidden) {
-                            case 1:
-                                // If Turnitin post date is in the next 7 days then push it ahead
-                                if ($post_date < (time() + (60 * 60 * 24 * 7)))  {
-                                    $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
-                                }
-                                break;
-                            case 0:
-                                if ($post_date > time()) {
-                                    $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
-                                }
-                                break;
-                            default:
-                                if ($post_date != $gradeitem->hidden) {
-                                    $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
-                                }
-                                break;
+                        if ($dtstart > time()) {
+                            break;
                         }
-                    } else {
-                        $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
+                
+                        if ($plagiarism_post_date = $DB->get_record_select('plagiarism_turnitin_config',
+                                " name = ? AND cm = ? ", array('plagiarism_post_date', $cm->id), 'value')) {
+                
+                                $post_date = $plagiarism_post_date->value;
+                                $gradeitem = $DB->get_record('grade_items', array('iteminstance' => $cm->instance,
+                                        'itemmodule' => $cm->modname, 'itemnumber' => 0));
+                
+                                // 1 means grade is always hidden, 0 means it's never hidden so we make it the same as start date.
+                                // Otherwise there is a hidden until date which we use as the post date.
+                                switch ($gradeitem->hidden) {
+                                    case 1:
+                                        // If Turnitin post date is in the next 7 days then push it ahead
+                                        if ($post_date < (time() + (60 * 60 * 24 * 7)))  {
+                                            $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
+                                        }
+                                        break;
+                                    case 0:
+                                        if ($post_date > time()) {
+                                            $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
+                                        }
+                                        break;
+                                    default:
+                                        if ($post_date != $gradeitem->hidden) {
+                                            $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
+                                        }
+                                        break;
+                                }
+                        } else {
+                            $this->sync_tii_assignment($cm, $coursedata->turnitin_cid);
+                        }
                     }
                 }
+            } catch (Exception $e) {
+                mtrace(get_string('editassignmenterror', 'turnitintooltwo'));
+                $turnitincomms->handle_exceptions($e, 'editassignmenterror', false);
+                return false;
             }
         }
 


### PR DESCRIPTION
Hi John, here's a patch to prevent the assignment update from crashing the cron job. It should partially deal with issue #112, although there would still need to be some exception handling for the events handlers to fix this completely.

Cheers

Michael
