### PR TITLE
Throw an access denied message to non site admins on link/unlink page

### DIFF
--- a/mod/turnitintooltwo/ajax.php
+++ b/mod/turnitintooltwo/ajax.php
@@ -148,6 +148,8 @@ switch ($action) {
         $PAGE->set_context(context_system::instance());
         if (is_siteadmin()) {
             echo json_encode(turnitintooltwo_getusers());
+        } else {
+            throw new moodle_exception('accessdenied', 'admin');
         }
         break;
 


### PR DESCRIPTION
Hi,

When a non site admin accesses mod/turnitintooltwo/settings_extras.php?cmd=unlinkusers they are met with an invalid json response.

I think we should be throwing a moodle exception instead as it avoids confusion that the system is working as expected.

Cheers,


Dr Joseph Baxter
University of Nottingham