### PR TITLE
Fix page URLs

### DIFF
--- a/mod/turnitintooltwo/extras.php
+++ b/mod/turnitintooltwo/extras.php
@@ -188,7 +188,7 @@ $nav = ($cmd == "courses" || $cmd == "multiple_class_recreation" || $cmd == "cla
 // Build page.
 echo $turnitintooltwoview->output_header(null,
             null,
-            $_SERVER["REQUEST_URI"],
+            '/mod/turnitintooltwo/extras.php',
             $title,
             $title,
             $nav,

--- a/mod/turnitintooltwo/index.php
+++ b/mod/turnitintooltwo/index.php
@@ -39,7 +39,7 @@ require_login($course->id);
 
 // Print the header.
 $extranavigation = array(array('title' => get_string("modulenameplural", "turnitintooltwo"), 'url' => null));
-$turnitintooltwoview->output_header(null, $course, $_SERVER["REQUEST_URI"], get_string("modulenameplural", "turnitintooltwo"),
+$turnitintooltwoview->output_header(null, $course, '/mod/turnitintooltwo/index.php', get_string("modulenameplural", "turnitintooltwo"),
                                         $SITE->fullname, $extranavigation, '', '', true);
 
 echo $turnitintooltwoview->show_assignments($course);

--- a/mod/turnitintooltwo/view.php
+++ b/mod/turnitintooltwo/view.php
@@ -295,7 +295,7 @@ if (!empty($action)) {
 if ($viewcontext == "box" || $viewcontext == "box_solid") {
     $turnitintooltwoview->output_header($cm,
             $course,
-            $_SERVER["REQUEST_URI"],
+            '/mod/turnitintooltwo/view.php',
             '',
             '',
             array(),
@@ -314,7 +314,7 @@ if ($viewcontext == "box" || $viewcontext == "box_solid") {
 
     $turnitintooltwoview->output_header($cm,
             $course,
-            $_SERVER["REQUEST_URI"],
+            '/mod/turnitintooltwo/view.php',
             $turnitintooltwoassignment->turnitintooltwo->name,
             $SITE->fullname,
             $extranavigation,


### PR DESCRIPTION
The page URLs are broken when Moodle is deployed to a subdirectory.
$_SERVER["REQUEST_URI"] = '/2014/mod....

The GET vars still go through as you pass $_GET to moodle_url