### PR TITLE
Change database installer and upgrade

### DIFF
--- a/mod/turnitintooltwo/db/install.xml
+++ b/mod/turnitintooltwo/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/turnitintooltwo/db" VERSION="20070401" COMMENT="XMLDB file for Moodle mod/turnitin"
+<XMLDB PATH="mod/turnitintooltwo/db" VERSION="2015012701" COMMENT="XMLDB file for Moodle mod/turnitin"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
        >
@@ -53,7 +53,7 @@
                 <FIELD NAME="erater_style" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" PREVIOUS="erater_mechanics" NEXT="transmatch"/>
                 <FIELD NAME="transmatch" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" PREVIOUS="erater_style" NEXT="rubric"/>
                 <FIELD NAME="rubric" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" PREVIOUS="transmatch" NEXT="allownonor"/>
-                <FIELD NAME="allownonor" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" PREVIOUS="rubric"/>
+                <FIELD NAME="allownonor" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" PREVIOUS="rubric" NEXT="needs_updating"/>
                 <FIELD NAME="needs_updating" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" PREVIOUS="allownonor"/>
             </FIELDS>
             <KEYS>

--- a/plagiarism/turnitin/db/install.xml
+++ b/plagiarism/turnitin/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="plagiarism/turnitin/db" VERSION="20110831" COMMENT="XMLDB file for Moodle plagiarism/turnitin plugin"
+<XMLDB PATH="plagiarism/turnitin/db" VERSION="20150127" COMMENT="XMLDB file for Moodle plagiarism/turnitin plugin"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -13,14 +13,14 @@
         <FIELD NAME="externalid" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" PREVIOUS="identifier" NEXT="externalstatus"/>
         <FIELD NAME="externalstatus" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="externalid" NEXT="statuscode"/>
         <FIELD NAME="statuscode" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false" PREVIOUS="externalstatus" NEXT="similarityscore"/>
-        <FIELD NAME="similarityscore" TYPE="int" LENGTH="5" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" PREVIOUS="statuscode" NEXT="attempt"/>
+        <FIELD NAME="similarityscore" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" PREVIOUS="statuscode" NEXT="attempt"/>
         <FIELD NAME="attempt" TYPE="int" LENGTH="5" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="similarityscore" NEXT="apimd5"/>
         <FIELD NAME="apimd5" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="This is the md5 used in the last api call to Turnitin" PREVIOUS="attempt" NEXT="legacyteacher"/>
         <FIELD NAME="legacyteacher" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" COMMENT="flag to specify this should use legacy teacher to access file." PREVIOUS="apimd5" NEXT="transmatch"/>
-        <FIELD NAME="transmatch" TYPE="int" LENGTH="1" NOTNULL="false" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="legacyteacher" NEXT="lastmodified"/>
+        <FIELD NAME="transmatch" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="legacyteacher" NEXT="lastmodified"/>
         <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="transmatch" NEXT="grade"/>
-        <FIELD NAME="grade" TYPE="int" LENGTH="1" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" PREVIOUS="lastmodified" NEXT="submissiontype"/>
-        <FIELD NAME="submissiontype" TYPE="char" LENGTH="50" NOTNULL="false" SEQUENCE="false" PREVIOUS="grade" NEXT="orcapable" />
+        <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" PREVIOUS="lastmodified" NEXT="submissiontype"/>
+        <FIELD NAME="submissiontype" TYPE="text" LENGTH="medium" NOTNULL="false" SEQUENCE="false" PREVIOUS="grade" NEXT="orcapable" />
         <FIELD NAME="orcapable" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" PREVIOUS="submissiontype" NEXT="errorcode"/>
         <FIELD NAME="errorcode" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" PREVIOUS="orcapable" NEXT="errormsg"/>
         <FIELD NAME="errormsg" TYPE="text" LENGTH="medium" NOTNULL="false" SEQUENCE="false" PREVIOUS="errorcode"/>

--- a/plagiarism/turnitin/db/upgrade.php
+++ b/plagiarism/turnitin/db/upgrade.php
@@ -99,5 +99,54 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2014012406, 'plagiarism', 'turnitin');
     }
 
+    if ($oldversion < 2015012701) {
+        $table = new xmldb_table('plagiarism_turnitin_files');
+        $field1 = new xmldb_field('transmatch', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, null, null, 0, 'legacyteacher');
+        $field2 = new xmldb_field('lastmodified', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, null, null, 0, 'transmatch');
+        $field3 = new xmldb_field('grade', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, null, null, null, 'lastmodified');
+        $field4 = new xmldb_field('submissiontype', XMLDB_TYPE_TEXT, 'medium', null, null, null, null, 'grade');
+        $field5 = new xmldb_field('similarityscore', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, null, null, NULL, 'statuscode');
+
+        if (!$dbman->field_exists($table, $field1)) {
+            $dbman->add_field($table, $field1);
+        }
+        else {
+            $dbman->change_field_precision($table, $field1);
+        }
+
+        if (!$dbman->field_exists($table, $field2)) {
+            $dbman->add_field($table, $field2);
+        }
+        else {
+            $dbman->change_field_precision($table, $field2);
+        }
+
+        if (!$dbman->field_exists($table, $field3)) {
+            $dbman->add_field($table, $field3);
+        }
+        else {
+            $dbman->change_field_precision($table, $field3);
+        }
+
+
+        if (!$dbman->field_exists($table, $field4)) {
+            $dbman->add_field($table, $field4);
+        }
+        else {
+            $dbman->change_field_precision($table, $field4);
+        }
+
+
+        if (!$dbman->field_exists($table, $field5)) {
+            $dbman->add_field($table, $field5);
+        } else {
+            $dbman->change_field_type($table, $field5);
+            $dbman->change_field_default($table, $field5);
+            $dbman->change_field_precision($table, $field5);
+        }
+
+        upgrade_plugin_savepoint(true, 2015012701, 'plagiarism', 'turnitin');
+    }
+
     return $result;
 }

--- a/plagiarism/turnitin/version.php
+++ b/plagiarism/turnitin/version.php
@@ -5,7 +5,7 @@
  * and open the template in the editor.
  */
 
-$plugin->version =  2014012412;
+$plugin->version =  2015012701;
 $plugin->requires =  2012062500.00;
 $plugin->cron     = 300;
 $plugin->component = 'plagiarism_turnitin';


### PR DESCRIPTION
This fixes two bugs.

1. The installer did not work with Moodle 2.3.  `allownonor` in mod/turnitintooltwo/db/install.xml was missing the NEXT field.  This is not a problem in 2.4+.

2.  The fields `grade`, `similarityscore`, `submissiontype`, and `transmatch` had not been updated in the plagiarism/turnitin/db/install.xml file even though they had been changed in upgrade.php for version 2013081202.  

The effect is that the aboved fields for anyone who installed after version 2013081202 were incorrectly sized to store data returned from the remote TurnItIn API which causes DML write errors in Moodle, especially in the case when an assignment has more possible points than a tinyint could store.