### PR TITLE
repositoryoption isn't always set

### DIFF
--- a/mod/turnitintooltwo/settings.php
+++ b/mod/turnitintooltwo/settings.php
@@ -301,6 +301,10 @@ if ($ADMIN->fulltree) {
     $suboptions = array( 0 => get_string('norepository', 'turnitintooltwo'), 
                         1 => get_string('standardrepository', 'turnitintooltwo'));
 
+    if (!isset($config->repositoryoption)) {
+        $config->repositoryoption = 0;
+    }
+
     switch ($config->repositoryoption) {
         case 0; // Standard options
             $settings->add(new admin_setting_configselect('turnitintooltwo/default_submitpapersto',


### PR DESCRIPTION
For example, during installation the repositoryoption config option would not yet have been set.
This results in a warning when you install a fresh copy of Moodle.