### PR TITLE
Unnecessary get_peermark_assignments call in get_parts

### DIFF
--- a/mod/turnitintooltwo/lib.php
+++ b/mod/turnitintooltwo/lib.php
@@ -1231,7 +1231,7 @@ function turnitintooltwo_print_overview($courses, &$htmlarray) {
         $turnitintooltwoassignment = new turnitintooltwo_assignment($turnitintooltwo->id, $turnitintooltwo);
 
         $now = time();
-        $parts = $turnitintooltwoassignment->get_parts();
+        $parts = $turnitintooltwoassignment->get_parts(false);
 
         $cm = get_coursemodule_from_id('turnitintooltwo', $turnitintooltwo->coursemodule);
         $context = context_module::instance($cm->id);

--- a/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
+++ b/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
@@ -936,7 +936,7 @@ class turnitintooltwo_assignment {
      * @global type $DB
      * @return array Returns the parts or empty array if no parts are found
      */
-    public function get_parts($peermarks = true) {
+    public function get_parts() {
         global $DB;
         if ($parts = $DB->get_records("turnitintooltwo_parts", array("turnitintooltwoid" => $this->turnitintooltwo->id))) {
             return $parts;

--- a/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
+++ b/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
@@ -934,11 +934,17 @@ class turnitintooltwo_assignment {
      * Get the assignment parts for this assignment
      *
      * @global type $DB
+     * @param bool $peermarks get peer mark assignments
      * @return array Returns the parts or empty array if no parts are found
      */
-    public function get_parts() {
+    public function get_parts($peermarks = true) {
         global $DB;
         if ($parts = $DB->get_records("turnitintooltwo_parts", array("turnitintooltwoid" => $this->turnitintooltwo->id))) {
+            if ($peermarks) {
+                foreach ($parts as $part) {
+                    $parts[$part->id]->peermark_assignments = $this->get_peermark_assignments($part->tiiassignid);
+                }
+            }
             return $parts;
         } else {
             return array();

--- a/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
+++ b/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
@@ -936,12 +936,9 @@ class turnitintooltwo_assignment {
      * @global type $DB
      * @return array Returns the parts or empty array if no parts are found
      */
-    public function get_parts() {
+    public function get_parts($peermarks = true) {
         global $DB;
         if ($parts = $DB->get_records("turnitintooltwo_parts", array("turnitintooltwoid" => $this->turnitintooltwo->id))) {
-            foreach ($parts as $part) {
-                $parts[$part->id]->peermark_assignments = $this->get_peermark_assignments($part->tiiassignid);
-            }
             return $parts;
         } else {
             return array();


### PR DESCRIPTION
Hi,

We have been reviewing our course  overview page performance, and spotted this as a possible improvement (less db calls).

It looks like the peermark_assignments is not used by the turnitintooltwo_print_overview caller function.

I have done a small amount of testing, but I imagine you will have a better test suite to test this change against.