### PR TITLE
Remove unused code.

### DIFF
--- a/plagiarism/turnitin/lib.php
+++ b/plagiarism/turnitin/lib.php
@@ -380,27 +380,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         return $output;
     }
 
-    private function get_max_files_allowed($moduleid, $modname) {
-        global $DB;
-        $filesallowed = 1;
-        switch($modname) {
-            case "assign":
-                $moduledata = $DB->get_record('assign_plugin_config',
-                                array('assignment' => $moduleid, 'name' => 'maxfilesubmissions'), 'value');
-                $filesallowed = $moduledata->value;
-                break;
-            case "forum":
-                $moduledata = $DB->get_record($modname, array('id' => $moduleid), 'maxattachments');
-                $filesallowed = $moduledata->maxattachments;
-                break;
-            case "workshop":
-                $moduledata = $DB->get_record($modname, array('id' => $moduleid), 'nattachments');
-                $filesallowed = $moduledata->nattachments;
-                break;
-        }
-
-        return $filesallowed;
-    }
 
     /**
      *
@@ -2251,7 +2230,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         global $CFG, $DB, $USER;
 
         $settings = $this->get_settings($cm->id);
-        $nooffilesallowed = $this->get_max_files_allowed($cm->instance, $cm->modname);
 
         // Do not submit if 5 attempts have been made previously.
         $previoussubmissions = $DB->get_records_select('plagiarism_turnitin_files',


### PR DESCRIPTION
The function get_max_files_allowed is not used.  This commit removes
it from the code.  I'm pretty sure this is a dead code path. Here's why:

Output from cron tells us PHP Notice: ```Trying to get property of non-object in /home/moodle/2.6/docs/plagiarism/turnitin/lib.php on line 359```

plagiarism/turnitin/lib.php:359 is in ```private function get_max_files_allowed($moduleid, $modname)```. It reads a value from the database and returns an int.

Find where ```get_max_files_allowed()``` is called:
```
jkerzner@horse:~/prj/moodle/git/docs$ grep -irn get_max_files_allowed *
plagiarism/turnitin/lib.php:352:    private function get_max_files_allowed($moduleid, $modname) {
plagiarism/turnitin/lib.php:2009:        $nooffilesallowed = $this->get_max_files_allowed($cm->instance, $cm->modname);
```

Find out where ```$nooffilesallowed``` is used:
```
jkerzner@horse:~/prj/moodle/git/docs$ grep -irn nooffilesallowed *
plagiarism/turnitin/lib.php:2009:        $nooffilesallowed = $this->get_max_files_allowed($cm->instance, $cm->modname);
```