### PR TITLE
Fixe "Close" link text in the Quickmark manager

### DIFF
--- a/plagiarism/turnitin/turnitinplugin_view.class.php
+++ b/plagiarism/turnitin/turnitinplugin_view.class.php
@@ -100,6 +100,7 @@ class turnitinplugin_view {
         global $CFG, $OUTPUT, $PAGE, $USER, $DB;
 
         $PAGE->requires->string_for_js('changerubricwarning', 'turnitintooltwo');
+        $PAGE->requires->string_for_js('closebutton', 'turnitintooltwo');
         $config = turnitintooltwo_admin_config();
         $config_warning = '';
 


### PR DESCRIPTION
Fixed issue where the "Close" link appears as "Undefined" in the Quickmark manager.