### PR TITLE
Avoid endless loops when creating temporary files

### DIFF
--- a/mod/turnitintooltwo/lib.php
+++ b/mod/turnitintooltwo/lib.php
@@ -608,29 +608,41 @@ function turnitintooltwo_tempfile(array $filename, $suffix) {
 
     $filename = implode('_', $filename);
     $filename = str_replace(' ', '_', $filename);
-    
-    $fp = false;
-    $tempdir = $CFG->dataroot.'/temp/turnitintooltwo';
-    if (!file_exists($tempdir)) {
-        mkdir( $tempdir, $CFG->directorypermissions, true );
-    }
-    // Get file extension and shorten filename if too long.
+
+    $tempdir = make_temp_directory('turnitintooltwo');
+
+    // Get the file extension (if there is one).
     $pathparts = explode('.', $suffix);
-    $ext = array_pop($pathparts);
+    if (count($pathparts) > 1) {
+        $ext = '.' . array_pop($pathparts);
+    } else {
+        $ext = '';
+    }
 
     $permittedstrlength = TURNITINTOOLTWO_MAX_FILENAME_LENGTH - strlen($tempdir.DIRECTORY_SEPARATOR);
-    if (strlen($filename) > $permittedstrlength) {
-        $filename = substr($filename, 0, $permittedstrlength);
+    $extlength = strlen('_' . mt_getrandmax() . $ext);
+    if ($extlength > $permittedstrlength) {
+        // Someone has likely used a filename with an absurdly long extension, or the
+        // tempdir path is huge, so preserve the extension as much as possible.
+        $extlength = $permittedstrlength;
     }
 
-    // filename with random string at the end
-    $filename = $filename . '_' . mt_rand() . '.'.$ext;
+    // Shorten the filename as needed, taking the extension into consideration.
+    $permittedstrlength -= $extlength;
+    $filename = substr($filename, 0, $permittedstrlength);
 
-    while (!$fp) {
-        $file = $tempdir.DIRECTORY_SEPARATOR.$filename;
-        $fp = @fopen($file, 'w');
-    }
-    fclose($fp);
+    $tries = 0;
+    do {
+        if ($tries == 10) {
+            throw new invalid_dataroot_permissions("turnitintooltwo temporary file cannot be created.");
+        }
+        $tries++;
+
+        // Filename with random string at the end.
+        $file = $tempdir . DIRECTORY_SEPARATOR . $filename .
+            substr('_' . mt_rand() . $ext, 0, $extlength);
+    } while (!touch($file));
+
     return $file;
 }
 
@@ -1088,7 +1100,7 @@ function turnitintooltwo_getfiles($moduleid) {
  * @param array $options additional options affecting the file serving
  * @return bool false if file not found, does not return if found - just send the file
  */
-function turnitintooltwo_pluginfile($course, 
+function turnitintooltwo_pluginfile($course,
                 $cm,
                 context $context,
                 $filearea,


### PR DESCRIPTION
Firstly, I added a safety valve to prevent endless loops from being a concern if something bizarre prevents files being created. After 10 attempts with different random values it throws an exception.
    
Secondly, previously, filenames having no sensible extension could cause an endless loop as the filename was deemed the extension, and the concatenation of it to the constructed name produces something the OS rejects. This changes the logic to at least stay within the limits, preserving the extension as much as possible. Someone can still do silly things like name a file "Part 1.1 name <snip 100ch> here" making the extension appear to be "1 name <snip 100ch> here", but it will not cause the file path length to be erroneous.
