### PR TITLE
Strip control characters from assignment title to prevent errors.

### DIFF
--- a/mod/turnitintooltwo/view.php
+++ b/mod/turnitintooltwo/view.php
@@ -168,7 +168,7 @@ if (!empty($action)) {
             $post['submissiontext'] = optional_param('submissiontext', '', PARAM_TEXT);
             $post['submissiontext'] = trim($post['submissiontext']);
             $post['submissiontitle'] = optional_param('submissiontitle', '', PARAM_TEXT);
-            $post['submissiontitle'] = trim($post['submissiontitle']);
+            $post['submissiontitle'] = trim(filter_var($post['submissiontitle'], FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW));
             $post['studentsname'] = optional_param('studentsname', $USER->id, PARAM_INT);
             $post['studentsname'] = ($istutor) ? $post['studentsname'] : $USER->id;
             $post['submissionpart'] = required_param('submissionpart', PARAM_INT);


### PR DESCRIPTION
Strip control characters from assignment title to prevent errors.