### PR TITLE
Don't show resubmission warning when resubmissions disallowed

### DIFF
--- a/mod/turnitintooltwo/turnitintooltwo_view.class.php
+++ b/mod/turnitintooltwo/turnitintooltwo_view.class.php
@@ -1192,9 +1192,10 @@ class turnitintooltwo_view {
                 }
 
                 // Show warning to instructor if student can still resubmit.
-                $class = ($istutor && $turnitintooltwoassignment->turnitintooltwo->reportgenspeed > 0 &&
-                            time() < $parts[$partid]->dtdue || $turnitintooltwoassignment->turnitintooltwo->allowlate == 1 &&
-                                empty($submission->nmoodle)) ? " graded_warning" : "";
+                $canresubmit = $turnitintooltwoassignment->turnitintooltwo->reportgenspeed > 0;
+                $tutorbeforeduedate = $istutor && time() < $parts[$partid]->dtdue;
+                $allowedlate = $turnitintooltwoassignment->turnitintooltwo->allowlate == 1 && empty($submission->nmoodle);
+                $class = $canresubmit && ($tutorbeforeduedate || $allowedlate) ? 'graded_warning' : '';
 
                 // Output grademark icon.
                 $grade = $OUTPUT->box($OUTPUT->pix_icon('icon-edit',


### PR DESCRIPTION
When an assignment is set to allow late submissions, and is set with
genspeed=0 (no resubmissions allowed), the tutor/lecturer shouldn't be
warned that the student is able to resubmit.

Refactored the IF condiition to make it more readable while I was there.