### PR TITLE
Have the module settings section appear in the settings block

### DIFF
--- a/mod/turnitintooltwo/view.php
+++ b/mod/turnitintooltwo/view.php
@@ -102,6 +102,8 @@ if ($viewcontext == "window") {
     $PAGE->set_course($course);
 }
 
+$PAGE->set_cm($cm);
+
 // Configure URL correctly.
 $urlparams = array('id' => $id, 'a' => $a, 'part' => $part, 'user' => $user, 'do' => $do, 'action' => $action, 
                     'view_context' => $viewcontext);


### PR DESCRIPTION
Currently settings are only accessible via the update button. This sets
the cm so the navigation system knows to display the modules settings
tree.