### PR TITLE
Fix sort order of Submission Part Tab

### DIFF
--- a/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
+++ b/mod/turnitintooltwo/turnitintooltwo_assignment.class.php
@@ -973,7 +973,7 @@ class turnitintooltwo_assignment {
      */
     public function get_parts($peermarks = true) {
         global $DB;
-        if ($parts = $DB->get_records("turnitintooltwo_parts", array("turnitintooltwoid" => $this->turnitintooltwo->id))) {
+        if ($parts = $DB->get_records("turnitintooltwo_parts", array("turnitintooltwoid" => $this->turnitintooltwo->id), 'id ASC')) {
             if ($peermarks) {
                 foreach ($parts as $part) {
                     $parts[$part->id]->peermark_assignments = $this->get_peermark_assignments($part->tiiassignid);


### PR DESCRIPTION
The submission parts can don't always apply in the same order they have
been created because there isn't a part number to sort them by, and
without a order by clause, the DB is not guaranteed to return the
records in any specific order.

Previously in Turnitintool v1, the submissions tabs were ordered by
first to last created, so this change mimics that.