### PR TITLE
Set page context in ajax.php correctly

### DIFF
--- a/mod/turnitintooltwo/ajax.php
+++ b/mod/turnitintooltwo/ajax.php
@@ -19,6 +19,8 @@
  * @copyright 2012 iParadigms LLC
  */
 
+define('AJAX_SCRIPT', 1);
+
 require_once(__DIR__."/../../config.php");
 require_once(__DIR__."/lib.php");
 require_once(__DIR__."/turnitintooltwo_view.class.php");
@@ -52,6 +54,7 @@ switch ($action) {
 
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:grade', context_module::instance($cm->id))) {
             $fieldname = required_param('name', PARAM_ALPHA);
@@ -104,6 +107,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:read', context_module::instance($cm->id))) {
             $user = new turnitintooltwo_user($USER->id, "Learner");
@@ -133,6 +137,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:read', context_module::instance($cm->id))) {
             $submissionid = required_param('submission', PARAM_INT);
@@ -152,6 +157,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:grade', context_module::instance($cm->id))) {
 
@@ -188,6 +194,7 @@ switch ($action) {
         break;
 
     case "initialise_redraw":
+        $PAGE->set_context(context_system::instance());
         $return["aaData"] = array();
 
         echo json_encode($return);
@@ -202,6 +209,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
         $return = array();
 
         if (has_capability('mod/turnitintooltwo:read', context_module::instance($cm->id))) {
@@ -244,6 +252,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:grade', context_module::instance($cm->id))) {
             $turnitintooltwouser = new turnitintooltwo_user($USER->id, 'Instructor');
@@ -264,6 +273,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:read', context_module::instance($cm->id))) {
             $partid = required_param('part', PARAM_INT);
@@ -300,6 +310,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:read', context_module::instance($cm->id))) {
             $partid = required_param('part', PARAM_INT);
@@ -353,6 +364,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         if (has_capability('mod/turnitintooltwo:grade', context_module::instance($cm->id))) {
             echo $turnitintooltwoassignment->enrol_all_students($cm);
@@ -363,6 +375,8 @@ switch ($action) {
         $courseid = required_param('course', PARAM_INT);
         $assignmentid = required_param('assignment', PARAM_INT);
         $modulename = required_param('modulename', PARAM_ALPHA);
+
+        $PAGE->set_context(context_course::instance($courseid));
 
         if (has_capability('moodle/course:update', context_course::instance($courseid))) {
             // Set Rubric options to instructor rubrics.
@@ -406,9 +420,9 @@ switch ($action) {
         break;
 
     case "get_files":
+        $PAGE->set_context(context_system::instance());
         if (is_siteadmin()) {
             $modules = $DB->get_record('modules', array('name' => 'turnitintooltwo'));
-            $PAGE->set_context($modules);
             echo json_encode(turnitintooltwo_getfiles($modules->id));
         }
         break;
@@ -417,6 +431,7 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+        $PAGE->set_context(context_module::instance($cm->id));
 
         $return["aaData"] = array();
         if (has_capability('mod/turnitintooltwo:grade', context_module::instance($cm->id))) {
@@ -468,6 +483,7 @@ switch ($action) {
         break;
 
     case "search_classes":
+        $PAGE->set_context(context_system::instance());
         if (!confirm_sesskey()) {
             throw new moodle_exception('invalidsesskey', 'error');
         }
@@ -478,13 +494,13 @@ switch ($action) {
         $requestsource = optional_param('request_source', 'mod', PARAM_TEXT);
 
         $modules = $DB->get_record('modules', array('name' => 'turnitintooltwo'));
-        $PAGE->set_context($modules);
 
         $return = turnitintooltwo_get_courses_from_tii($tiiintegrationids, $coursetitle, $courseintegration, $courseenddate, $requestsource);
         echo json_encode($return);
         break;
 
     case "create_courses":
+        $PAGE->set_context(context_system::instance());
         set_time_limit(0);
         if (!confirm_sesskey()) {
             throw new moodle_exception('invalidsesskey', 'error');
@@ -525,6 +541,7 @@ switch ($action) {
         break;
 
     case "create_course":
+        $PAGE->set_context(context_system::instance());
         if (!confirm_sesskey()) {
             throw new moodle_exception('invalidsesskey', 'error');
         }
@@ -565,6 +582,8 @@ switch ($action) {
             $turnitincourse->turnitin_ctl = urldecode($tiicoursename);
             $turnitincourse->course_type = 'TT';
 
+            $PAGE->set_context(context_course::instance($coursetolink));
+
             if (!$insertid = $DB->insert_record('turnitintooltwo_courses', $turnitincourse)) {
                 echo "0";
             } else {
@@ -583,6 +602,8 @@ switch ($action) {
         if (!confirm_sesskey()) {
             throw new moodle_exception('invalidsesskey', 'error');
         }
+
+        $PAGE->set_context(context_system::instance());
 
         if (has_capability('moodle/course:update', context_system::instance())) {
             $tiicourseid = required_param('tii_course_id', PARAM_INT);
@@ -628,6 +649,8 @@ switch ($action) {
 
             $enddate = mktime(00, 00, 00, $enddatem, $enddated, $enddatey);
 
+            $PAGE->set_context(context_system::instance());
+
             if (turnitintooltwo_assignment::edit_tii_course_end_date($tiicourseid, $tiicoursetitle, $enddate)) {
                 $return["status"] = "success";
                 $return["end_date"] = userdate($enddate, get_string('strftimedate', 'langconfig'));
@@ -649,6 +672,8 @@ switch ($action) {
         $data = '';
         $current_version = required_param('current_version', PARAM_INT);
 
+        $PAGE->set_context(context_system::instance());
+
         if (is_siteadmin()) {
             $data = turnitintooltwo_updateavailable($current_version);
         }
@@ -661,6 +686,7 @@ switch ($action) {
         }
         $data = array("connection_status" => "fail", "msg" => get_string('connecttestcommerror', 'turnitintooltwo'));
 
+        $PAGE->set_context(context_system::instance());
         if (is_siteadmin()) {
             // Initialise API connection.
 
@@ -696,6 +722,8 @@ switch ($action) {
         $assignmentid = required_param('assignment', PARAM_INT);
         $turnitintooltwoassignment = new turnitintooltwo_assignment($assignmentid);
         $cm = get_coursemodule_from_instance("turnitintooltwo", $assignmentid);
+
+        $PAGE->set_context(context_system::instance());
 
         if (has_capability('mod/turnitintooltwo:grade', context_module::instance($cm->id))) {
             $partid = required_param('part', PARAM_INT);


### PR DESCRIPTION
The turnitintooltwo module is outputting warnings in its ajax script as
the $PAGE->context is not being set, or is set incorrectly. This variable needs
to be set appropriately based on the requested action.