### PR TITLE
Fix backup/restore of submission files

### DIFF
--- a/mod/turnitintooltwo/backup/moodle2/backup_turnitintooltwo_stepslib.php
+++ b/mod/turnitintooltwo/backup/moodle2/backup_turnitintooltwo_stepslib.php
@@ -115,7 +115,7 @@ class backup_turnitintooltwo_activity_structure_step extends backup_activity_str
 
         // Define file annotations
         $turnitintooltwo->annotate_files('mod_turnitintooltwo', 'intro', null); // This file area hasn't itemid
-        $submission->annotate_files('mod_turnitintooltwo', 'submission', 'id');
+        $submission->annotate_files('mod_turnitintooltwo', 'submissions', 'id');
 
         // Return the root element (turnitintooltwo), wrapped into standard activity structure
         return $this->prepare_activity_structure($turnitintooltwo);

--- a/mod/turnitintooltwo/backup/moodle2/restore_turnitintooltwo_stepslib.php
+++ b/mod/turnitintooltwo/backup/moodle2/restore_turnitintooltwo_stepslib.php
@@ -156,7 +156,7 @@ class restore_turnitintooltwo_activity_structure_step extends restore_activity_s
         }
 
         $newitemid = $DB->insert_record('turnitintooltwo_submissions', $data);
-        $this->set_mapping('turnitintooltwo_submissions', $oldid, $newitemid);
+        $this->set_mapping('turnitintooltwo_submissions', $oldid, $newitemid, true);
     }
 
     protected function after_execute() {
@@ -165,5 +165,8 @@ class restore_turnitintooltwo_activity_structure_step extends restore_activity_s
             $_SESSION["assignments_to_create"][] = $_SESSION['assignment_id'];
             unset($_SESSION['assignment_id']);
         }
+
+        // Add turnitin related files, itemid based on mapping 'turnitintooltwo_submissions'.
+        $this->add_related_files('mod_turnitintooltwo', 'submissions', 'turnitintooltwo_submissions');
     }
 }


### PR DESCRIPTION
Submission files aren't correctly pulled into backups or annotated,
causing them to not restore properly into the new course.